### PR TITLE
Return success flag from file search

### DIFF
--- a/FileRemover/Services/FileService.cs
+++ b/FileRemover/Services/FileService.cs
@@ -45,17 +45,20 @@ public class FileService
         _files.Clear();
         _worker = backgroundWorkerGetFiles;
 
+        bool success;
         try
         {
             RetrieveFilesFromAllDirectories(directoryDetails.SelectedPath, directoryDetails);
+            success = true;
         }
         catch (Exception e)
         {
             Debug.WriteLine($"Unexpected error occured: {e}");
+            success = false;
         }
 
 
-        return (_files, true);
+        return (_files, success);
     }
 
     private void RetrieveFilesFromAllDirectories(string rootPath, DirectoryDetails details)


### PR DESCRIPTION
## Summary
- propagate a success flag from `SearchForFilesInDirectory`
- return false when an exception occurs

## Testing
- `dotnet build FileRemover.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865283a2ac0832490e2df2110a4b903