### PR TITLE
Initialize ServiceProvider

### DIFF
--- a/FileRemover/Program.cs
+++ b/FileRemover/Program.cs
@@ -24,7 +24,7 @@ internal static class Program
         Application.Run(ServiceProvider.GetRequiredService<MainWindowForm>());
     }
 
-    public static IServiceProvider ServiceProvider { get; private set; }
+    public static IServiceProvider ServiceProvider { get; private set; } = null!;
 
     private static IHostBuilder CreateHostBuilder()
     {


### PR DESCRIPTION
## Summary
- initialize `ServiceProvider` with `null!` to satisfy nullable analysis

## Testing
- `dotnet build FileRemover.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865283a7600832495c9b9817797a1ed